### PR TITLE
correction to self.logits assignment in VDCNN

### DIFF
--- a/vdcnn.py
+++ b/vdcnn.py
@@ -212,7 +212,7 @@ class VDCNN(Model):
         self.pool_type = pool_type
         self.proj_type = proj_type
         self.use_bias = use_bias
-        self.logits = True
+        self.logits = logits
 
         assert pool_type in ['max', 'k_max', 'conv']
         assert proj_type in ['conv', 'identity']


### PR DESCRIPTION
in __init__(), self.logits was =True, which is incorrect. Should be =logits, which takes in the required Boolean value (logits) from the function arguments instead of being set to True always.